### PR TITLE
Support IPV6

### DIFF
--- a/app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java
+++ b/app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java
@@ -1900,10 +1900,6 @@ public class TunnelManager extends VpnService implements Runnable, ConnectionMon
                 builder.addDisallowedApplication(mContext.getPackageName());
             }
 
-            if (!isBypass && isIpv6) {
-                //builder.addDisallowedApplication(mContext.getPackageName());
-            }
-
 
             tunFd = builder
                     .setSession(getApplicationName())


### PR DESCRIPTION
This pull request includes significant changes to the `TunnelManager` class in the `app/one/secondvpnlite/service` package. The primary focus of these changes is to enhance IPv6 support and clean up the code.

Enhancements to IPv6 support:

* [`app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java`](diffhunk://#diff-22c8f72dc1bedfc05419be202f6359c020fa4e4e95704c583a0775e2ae8b9e34R1630-L1642): Added logic to handle IPv6 addresses in the `establishVpn` method. This includes checking if the `hostString` contains a colon to determine if it is an IPv6 address, initializing `Inet6Address` and `Inet4Address` variables, and adding the appropriate addresses to the routes.

Code cleanup:

* [`app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java`](diffhunk://#diff-22c8f72dc1bedfc05419be202f6359c020fa4e4e95704c583a0775e2ae8b9e34L1858-L1861): Removed redundant checks and commented-out code related to IPv6 in the `establishVpn` method.
* [`app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java`](diffhunk://#diff-22c8f72dc1bedfc05419be202f6359c020fa4e4e95704c583a0775e2ae8b9e34R1972): Cleaned up unnecessary empty lines in the `connectTunnel` method.
* [`app/src/main/java/app/one/secondvpnlite/service/TunnelManager.java`](diffhunk://#diff-22c8f72dc1bedfc05419be202f6359c020fa4e4e95704c583a0775e2ae8b9e34R2263-R2271): Added a new private method `GetIPV6Mask` to parse the subnet mask from a CIDR notation string.